### PR TITLE
Setuptools: adding scripts for easier dependencies installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you already have a patch-based preprocessed dataset, you may skip to Stage 3 
 
 1. `all_wsi` has a folder for each class as a placeholder (they can be empty).
 
-2. Both `train_folder/train` and `train_folder/val` folders contain a folder for each slide that belongs to its partition. The slide folder should contain at least one patch extracted from the slide.
+2. Both `train_folder/train` and `train_folder/val` folders contain a folder for each class and each slide that belongs to its partition. The slide folder should contain at least one patch extracted from the slide (e.g., `train_folder/train/<class_name>/<slide_name>/<patch_file>`).
 
 3. Review `code/config.py` and make appropriate/necessary changes for your dataset.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We have made 143 digitized high-resolution histology slides of lung adenocarcino
 
 ## Requirements
 - [imageio](https://pypi.org/project/imageio/)
-- [NumPy](https://numpy.org/)
+- [NumPy 1.16+](https://numpy.org/)
 - [OpenCV](https://opencv.org/)
 - [OpenSlide](https://openslide.org/)
 - [OpenSlide Python](https://openslide.org/api/python/)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ If you do not want to duplicate the data, append `--keep_orig_copy False` to the
 
 Note that `all_wsi` must contain subfolders of images labeled by class. For instance, if your two classes are `a` and `n`, you must have `a/*.jpg` with the images in class `a` and `n/*.jpg` with images in class `n`.
 
+If you already have a patch-based preprocessed dataset, you may skip to Stage 3 for model training. Please make sure that at least:
+
+1. `all_wsi` has a folder for each class as a placeholder (they can be empty).
+
+2. Both `train_folder/train` and `train_folder/val` folders contain a folder for each slide that belongs to its partition. The slide folder should contain at least one patch extracted from the slide.
+
+3. Review `code/config.py` and make appropriate/necessary changes for your dataset.
+
 ### Example
 ```
 python code/1_split.py --val_wsi_per_class 10 --test_wsi_per_class 20

--- a/README.md
+++ b/README.md
@@ -11,19 +11,27 @@ We have made 143 digitized high-resolution histology slides of lung adenocarcino
 
 ## Requirements
 - [imageio](https://pypi.org/project/imageio/)
-- [NumPy 1.16](https://numpy.org/)
+- [NumPy](https://numpy.org/)
 - [OpenCV](https://opencv.org/)
 - [OpenSlide](https://openslide.org/)
 - [OpenSlide Python](https://openslide.org/api/python/)
 - [pandas](https://pandas.pydata.org/)
 - [PIL](https://pillow.readthedocs.io/en/5.3.x/)
-- [Python 3.6](https://www.python.org/downloads/release/python-360/)
+- [Python 3.7+](https://www.python.org/downloads/release/python-360/)
 - [PyTorch](https://pytorch.org/)
 - [scikit-image](https://scikit-image.org/)
 - [scikit-learn](https://scikit-learn.org/stable/install.html)
 - [SciPy](https://www.scipy.org/)
 - [NVIDIA GPU](https://www.nvidia.com/en-us/)
 - [Ubuntu](https://ubuntu.com/)
+
+## Installing Dependencies (Recommended method)
+
+`conda env create --file setup/conda_env.yaml`
+
+This command creates a conda environment called 'deepslide_env' with Python 3.9 and PyTorch with CUDA 11.3. Please modify the environment file(s) for other versions.
+
+In addition, `install_openslide.sh` installs dependencies of OpenSlide package in Ubuntu. For other platforms, please visit to the OpenSlide's official website for more information.
 
 # Usage
 

--- a/setup/conda_env.yaml
+++ b/setup/conda_env.yaml
@@ -1,0 +1,16 @@
+#$ conda env create --file conda-env.yaml
+name: deepslide_env
+channels:
+  - conda-forge
+  - pytorch
+dependencies:
+  - python=3.9
+  - torchvision
+  - cudatoolkit=11.3
+  - pandas
+  - matplotlib
+  - scikit-learn
+  - scikit-image
+  - pip
+  - pip:
+    - -r pip-requirements.txt

--- a/setup/install_openslide.sh
+++ b/setup/install_openslide.sh
@@ -1,0 +1,2 @@
+apt-get update
+apt-get install openslide-tools

--- a/setup/pip-requirements.txt
+++ b/setup/pip-requirements.txt
@@ -1,0 +1,6 @@
+numpy
+imageio
+pillow
+opencv-python
+openslide-python
+Jinja2


### PR DESCRIPTION
Existing documentation lists the required packages for this library; however, users have to manually identify the installation method for each package, which is not convenient. 

In this PR users can install all the necessary packages using conda environment file. Also a shell script is attached to install openslide backend which would be necessary on new machine and container.