### PR TITLE
Fixing a syntax issue in utils_model.py

### DIFF
--- a/code/utils_model.py
+++ b/code/utils_model.py
@@ -60,7 +60,12 @@ def calculate_confusion_matrix(all_labels: np.ndarray,
 
     cm = pd.crosstab(index=actual, columns=predicted, normalize="index", dropna=False)
 
-    cm.style.hide_index()
+    
+    # cm.style.hide_index() 
+    # Pandas hide_index method became deprecated since the version 1.4.0,
+    # should be replaced by:
+    cm.style.hide()
+
     print(cm)
 
 


### PR DESCRIPTION
Installing the packages as instructed in the article results in downloading a newer version of pandas, which causes an error. This error can be fixed by changing cm.style.hide_index() to cm.style.hide() in utils_model.py. This modification ensures that 3_train.py works with the newer versions of pandas due to changes in syntax.